### PR TITLE
Fix deadlock between auto-pause and action execution

### DIFF
--- a/Move Mouse/ViewModels/MouseWindowViewModel.cs
+++ b/Move Mouse/ViewModels/MouseWindowViewModel.cs
@@ -795,7 +795,7 @@ namespace ellabi.ViewModels
         private void StopAutoPauseTimer()
         {
             StaticCode.Logger?.Here().Debug(String.Empty);
-            
+
             lock (_pauseLock)
             {
                 try
@@ -814,13 +814,21 @@ namespace ellabi.ViewModels
             try
             {
                 StaticCode.Logger?.Here().Debug(StaticCode.GetLastInputTime().ToString());
+                bool shouldStop = false;
+                MouseState stopState = MouseState.Idle;
 
                 lock (_pauseLock)
                 {
                     if (CurrentState.Equals(MouseState.Running) && (StaticCode.GetLastInputTime() < TimeSpan.FromMilliseconds(_autoPauseTimer.Interval)))
                     {
-                        Stop((SettingsVm.Settings.AutoPause && SettingsVm.Settings.AutoResume) ? MouseState.Paused : MouseState.Idle);
+                        shouldStop = true;
+                        stopState = (SettingsVm.Settings.AutoPause && SettingsVm.Settings.AutoResume) ? MouseState.Paused : MouseState.Idle;
                     }
+                }
+
+                if (shouldStop)
+                {
+                    Stop(stopState);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
The lock-splitting change (splitting _lock into _actionsLock and _pauseLock) introduced a lock-ordering deadlock when AutoPause is enabled. _autoPauseTimer_Elapsed held _pauseLock and called Stop() which acquires _actionsLock, while PerformActions held _actionsLock and called StopAutoPauseTimer() which acquires _pauseLock.

Move the Stop() call outside the _pauseLock in _autoPauseTimer_Elapsed to break the circular dependency.